### PR TITLE
New `exclude` config for `retype.json`

### DIFF
--- a/configuration/project.md
+++ b/configuration/project.md
@@ -72,6 +72,25 @@ The path is relative to the `retype.json` location.
   "output": "./docs"
 }
 ```
+
++++
+
+### exclude
+
++++ exclude : `array`
+
+Array of folder and file path patterns to exclude from the build process.
+
+Relative paths are relative to the `input`.
+
+Allowed wildcards: `?`, `*`
+
+```json Sample: Ignore pages in a folder
+{
+  "exclude": "draft/"
+}
+```
+
 +++
 
 ### base

--- a/configuration/project.md
+++ b/configuration/project.md
@@ -87,7 +87,7 @@ Allowed wildcards: `?`, `*`
 
 ```json Sample: Ignore pages in a folder
 {
-  "exclude": "draft/"
+  "exclude": ["draft/"]
 }
 ```
 


### PR DESCRIPTION
This PR documents a new configuration setting in `retype.json` - `exclude`. 
This option will help to exclude specified pages and folders from the build process.