### PR TITLE
`v1.8` docs review

### DIFF
--- a/configuration/page.md
+++ b/configuration/page.md
@@ -320,7 +320,7 @@ Similarily, a page configured with `order: -100` will be lower in the navigation
 
 !!!
 
-The position of folders within the navigation can be [ordered](folder.md) too using the same `order` technique.
+The position of folders within the navigation can be [ordered](folder.md) too using the same `order` technique with the only difference that folders are always pinned to the top of their `order` group.
 
 !!!
 

--- a/configuration/project.md
+++ b/configuration/project.md
@@ -116,7 +116,7 @@ branding:
 
 === logoAlign : `string`
 
-Set a logo image alignment relative to the [`title`](#title). Supported values: `left`, `right`.
+Set a logo image alignment relative to the [`title`](#title). Supported values include `left` and `right`.
 
 Default is `left`.
 
@@ -166,21 +166,21 @@ Cache configuration options.
 ### busting
 
 Cache busting configuration for the website resources.
-Helps to ensure a loaded page refers to the most recent javascript and CSS resources.
+Helps to ensure a loaded page refers to the most recent JavaScript and CSS resources.
 
 === strategy : `string`
 
-Specifies the approach Retype will use for cache invalidating. 
+Specifies the approach Retype will use for cache invalidation. 
 
 | Strategy     | Description |
 | ------------ | ----------- |
 | `none`       | Cache invalidation is disabled. |
-| `path`       | Cache invalidation is achieved by concatinating a version token with a file name. |
-| `query`      | Cache invalidation is achieved by using a query parameter with a version token value. |
+| `path`       | Cache invalidation is achieved by concatinating the file name with a version token. |
+| `query`      | Cache invalidation is achieved by adding a query parameter with a version token value. |
 
 Default is `query`.
 
-Below are demo URLs generated for corresponding `cache.busting.strategy` values.
+Below are demo URLs generated for corresponding `cache.busting.strategy` options:
 
 ~~~html `strategy: none`
 <script type="text/javascript" src="/resources/js/retype.js" />

--- a/configuration/project.md
+++ b/configuration/project.md
@@ -159,6 +159,55 @@ branding:
 
 ---
 
+## cache
+
+Cache configuration options.
+
+### busting
+
+Cache busting configuration for the website resources.
+Helps to ensure a loaded page refers to the most recent javascript and CSS resources.
+
+=== strategy : `string`
+
+Specifies the approach Retype will use for cache invalidating. 
+
+| Strategy     | Description |
+| ------------ | ----------- |
+| `none`       | Cache invalidation is disabled. |
+| `path`       | Cache invalidation is achieved by concatinating a version token with a file name. |
+| `query`      | Cache invalidation is achieved by using a query parameter with a version token value. |
+
+Default is `query`.
+
+Below are demo URLs generated for corresponding `cache.busting.strategy` values.
+
+~~~html `strategy: none`
+<script type="text/javascript" src="/resources/js/retype.js" />
+~~~
+
+~~~html `strategy: path`
+<script type="text/javascript" src="/resources/js/retype.v1.10.js" />
+~~~
+
+~~~html `strategy: query`
+<script type="text/javascript" src="/resources/js/retype.js?v=1.10" />
+~~~
+
+===
+
+=== token : `string`
+
+An optional unique token used for website resource cache invalidation.
+
+- If specified, the provided value is used for all invalidatable resources as is.
+- If not specified, the default token having the following structure is used:  
+`{Retype version}.{total milliseconds elapsed since 2000-01-01}`
+
+===
+
+---
+
 ## cname
 
 === cname : `boolean` or `string`

--- a/configuration/project.md
+++ b/configuration/project.md
@@ -112,6 +112,21 @@ branding:
 ```
 ===
 
+### logoAlign
+
+=== logoAlign : `string`
+
+Set a logo image alignment relative to the [`title`](#title). Supported values: `left`, `right`.
+
+Default is `left`.
+
+```yml
+branding:
+  logo: static/logo.png
+  logoAlign: right
+```
+===
+
 ### colors
 
 Custom color configuration.

--- a/configuration/project.md
+++ b/configuration/project.md
@@ -530,6 +530,25 @@ There are several other values that may be prefixed with an `_` character, inclu
 
 ---
 
+## markdown
+
+Markdown configuration options.
+
+### lineBreaks
+
+=== lineBreaks : `string`
+
+Switches between `soft` and `hard` line break modes. The option instructs Retype in what way a regular line ending should be handled.
+
+- in `soft` mode, regular line breaks are processed as [soft breaks](https://spec.commonmark.org/0.30/#soft-line-breaks) (no `<br />` is emitted to HTML markup), unless a line contains 2+ spaces before a line break.
+- in `hard` mode, regular line breaks are always emitted as `<br />` HTML elements.
+
+Default is `soft`.
+
+===
+
+---
+
 ## meta
 
 Project wide meta tag configuration options.


### PR DESCRIPTION
Adds missing documentation parts for the features introduced in `v1.8` (or before):

- Ability to configure a website logo alignment using the `branding.logoAlign` config
- The `markdown.lineBreaks` option for configuring how line breaks are processed by Retype
- Website resources cache buster