### PR TITLE
Reviews page config's 'author' documentation to include 'email' field info.

### DIFF
--- a/configuration/page.md
+++ b/configuration/page.md
@@ -49,12 +49,10 @@ See [folder configuration](folder.md) for details on how to configure a folder.
 
 ---
 
-## author
+## author / authors
 
 !!!
-
-The configuration name `authors` is also supported. The name `authors` is an alias of `author` and both can be used interchangeably.
-
+The name `authors` is an alias of `author` and both can be used interchangeably.
 !!!
 
 === author : `string`, `list`, or `object`
@@ -63,28 +61,29 @@ The author or multiple authors of this page.
 
 ```yml
 ---
-author: Frank
+author: John Doe
 ---
 ```
 
 ```yml
 ---
-author: frank@example.com
+author: john.doe@example.com
 ---
 ```
 
-An author object can also be configured with specific values for the `lable`, `link`, and `avatar`.
+An `author` object can be configured with specific values for the `avatar` picture URL, `name`, `email`, and website `link`'s URL.
 
 ```yml
 ---
 author:
-  name: Frank Esposito
-  link: https://twitter.com/frank # custom link take precedence
-  avatar: https://example.com/frank.jpg # custom avatar takes precedence
+  name: John Doe
+  email: john.doe@example.com
+  link: https://twitter.com/john.doe # custom link take precedence
+  avatar: https://example.com/johndoe.jpg # custom avatar takes precedence
 ---
 ```
 
-Possible options for the `avatar` include:
+Possible options for the `avatar` config include:
 
 1. Path to local image
 2. URL to an external image
@@ -96,7 +95,7 @@ The `author` config is very flexible and can accept one or more author configura
 
 ```yml
 ---
-authors: [Frank, Annette Jones, steffen@example.com]
+authors: [John Doe, Annette Jones, steffen@example.com]
 ---
 ```
 
@@ -106,11 +105,14 @@ Mixed author types are also permitted, including adding a list of authors by nam
 ---
 # Mix of author types
 authors:
-  - name: Frank Esposito
-    link: https://twitter.com/frank
-    avatar: https://example.com/frank.jpg
+  - name: John Doe
+    email: john.doe@example.com
+    link: https://twitter.com/john.doe
+    avatar: https://example.com/johndoe.jpg
   - Annette Jones
   - steffen@example.com
+  - name: Jane Doe
+    email: jane.doe@example.com
 ---
 ```
 


### PR DESCRIPTION
Adds references to the 'email' setting that was not documented.

Notice this is _not_ related to gravatars support being implemented in v1.10. This is simply a review adding a configuration setting that was not documented.

Upon review and merge, I'll handle syncing this up to the upcoming `dev` and make a new pull request adding info regarding gravatars.