### PR TITLE
Adds examples for URL base paths in components that takes links.

### DIFF
--- a/components/file-download.md
+++ b/components/file-download.md
@@ -48,3 +48,19 @@ By default, the file name is used as the component text value but the text can b
 ```
 
 [!file icon="rocket" text="To the moon"](../static/sample.txt)
+
+## Tilde base URL token
+
+This component support tilde url tokens. They are especially useful in case retype is deployed as a subdirectory in a domain, e.g. `http://example.com/docs`. Links starting with `~` are prefixed the base directory retype is expected to be running at.
+
+From the examples above, most of them retrieve `/static/sample.txt` by its relative path to this page, `../static/sample.txt`. Using tokens, it is possible to safely use a link that could be copy-pasted to other articles without need to fix paths:
+
+```md
+[!file](~/static/sample.txt)
+```
+
+[!file](~/static/sample.txt)
+
+!!!
+In this case, if the website URL were `http://example.com/docs`, then the resolved link would have been `http://example.com/docs/static/sample.txtr.
+!!!

--- a/components/image.md
+++ b/components/image.md
@@ -87,3 +87,19 @@ The `plus` alignment options only apply when the page is `layout: central` or `l
 For default page layouts with a left navigation and/or the right table of contents, the `plus` positions will fallback to their non-plus equivalents. For instance, `rightplus` will fallback to `right` and the `centerplus` will fallback to `center`.
 
 Photo by [carlos aranda](https://unsplash.com/@carlosaranda) on [Unsplash](https://unsplash.com/).
+
+## Tilde base URL token
+
+This component support tilde url tokens. They are especially useful in case retype is deployed as a subdirectory in a domain, e.g. `http://example.com/docs`. Links starting with `~` are prefixed the base directory retype is expected to be running at.
+
+From the examples above, most of them retrieve `/static/sample.jpg` by its relative path to this page, `../static/sample.jpg`. Using tokens, it is possible to safely use a link that could be copy-pasted to other articles without need to fix paths:
+
+```md
+![](~/static/sample.jpg)
+```
+
+![](~/static/sample.jpg)
+
+!!!
+In this case, if the website URL were `http://example.com/docs`, then the resolved link would have been `http://example.com/docs/static/sample.jpg.
+!!!

--- a/components/reference-link.md
+++ b/components/reference-link.md
@@ -28,3 +28,58 @@ The text of the link can be explicitly set by passing as the first part of the c
 Clicking anywhere within the reference link component will navigate to that new page.
 
 From a functionality perspective, there is no difference betwen a `!ref` component and a regular hyperlink. The difference between the two is just how they are presented, with a Reference link component being more prominent than a regular hyperlink.
+
+
+## Tilde base URL token
+
+This component supports the tilde base URL token (`~`). This URL token prepends Retype's configured base address to the provided address, which should be a path to the same website (no `https://website.com/`).
+
+### Examples
+
+#### Links to a page in the same folder
+
+```md
+[!ref alert.md](alert.md)
+[!ref alert](alert)
+
+[!ref ~/components/alert.md (invalid)](~/components/alert.md)
+[!ref ~/components/alert (valid)](~/components/alert)
+```
+
+[!ref alert.md](alert.md)
+[!ref alert](alert)
+
+[!ref ~/components/alert.md (invalid)](~/components/alert.md)
+[!ref ~/components/alert (valid)](~/components/alert)
+
+!!! Link resolution
+Links with tilde expansion won't resolve against `.md` files. Simply omitting the file extension should make it so the link works.
+!!!
+
+#### Links to website root
+
+```md
+[!ref /about](/about)
+[!ref ../about](../about)
+
+[!ref ~/about](~/about)
+```
+
+[!ref /about](/about)
+[!ref ../about](../about)
+
+[!ref ~/about](~/about)
+
+#### Links to a page in another folder
+
+```md
+[!ref /guides/getting-started](/guides/getting-started)
+[!ref ../guides/getting-started](../guides/getting-started.md)
+
+[!ref ~/guides/getting-started](~/guides/getting-started)
+```
+
+[!ref /guides/getting-started](/guides/getting-started)
+[!ref ../guides/getting-started](../guides/getting-started.md)
+
+[!ref ~/guides/getting-started](~/guides/getting-started)


### PR DESCRIPTION
Adds samples to components that can take tilde in the beginning of the address (prepend base path to url).

We should find the best place where to document the feature in general, as also normal links `[link](~/address)` supports this feature.

Once we have a "central article" for the feature, the image, file and ref components can just point to that document and limit to simple examples.