### PR TITLE
Reference link attributes docs

### DIFF
--- a/components/file-download.md
+++ b/components/file-download.md
@@ -31,15 +31,22 @@ Clicking anywhere within the file download component will trigger the web browse
 
 ## Custom icon
 
-The `icon` used for the file download component can be customized using a name/value pair syntax for the `text` and `icon` attributes. This allows for setting a custom `icon` and `text` value at the same time.
+The `icon` used for the file download component can be customized using a name/value pair syntax for the `text` and `icon` attributes. This allows for setting a custom `icon` and `text` value at the same time. The `icon` attribute can be initialize with one of the following:
+- [Octicon](https://octicons-primer.vercel.app/octicons/) name
+- emoji `:shortcode:` (please see [Mojee](https://mojee.io/emojis) for a full list of supported Emoji shortcodes)
+- image file URL
 
-The following sample demonstrates setting a custom `icon`:
+The following samples demonstrate setting a custom `icon`:
 
 ```
 [!file icon="rocket"](../static/sample.txt)
+[!file icon=":rocket:"](../static/sample.txt)
+[!file icon="../static/retype-icon.svg"](../static/sample.txt)
 ```
 
 [!file icon="rocket"](../static/sample.txt)
+[!file icon=":rocket:"](../static/sample.txt)
+[!file icon="../static/retype-icon.svg"](../static/sample.txt)
 
 By default, the file name is used as the component text value but the text can be customized by explicityly passing a separate `text` value.
 

--- a/components/file-download.md
+++ b/components/file-download.md
@@ -33,8 +33,8 @@ Clicking anywhere within the file download component will trigger the web browse
 
 The `icon` used for the file download component can be customized using a name/value pair syntax for the `text` and `icon` attributes. This allows for setting a custom `icon` and `text` value at the same time. The `icon` attribute can be initialize with one of the following:
 - [Octicon](https://octicons-primer.vercel.app/octicons/) name
-- emoji `:shortcode:` (please see [Mojee](https://mojee.io/emojis) for a full list of supported Emoji shortcodes)
-- image file URL
+- Emoji `:shortcode:` (please see [Mojee](https://mojee.io/emojis) for a full list of supported Emoji shortcodes)
+- Image file URL
 
 The following samples demonstrate setting a custom `icon`:
 
@@ -48,7 +48,7 @@ The following samples demonstrate setting a custom `icon`:
 [!file icon=":rocket:"](../static/sample.txt)
 [!file icon="../static/retype-icon.svg"](../static/sample.txt)
 
-By default, the file name is used as the component text value but the text can be customized by explicityly passing a separate `text` value.
+By default, the referred page title is used as the component text value and the text can be customized by explicitly passing a separate `text` value.
 
 ```
 [!file icon="rocket" text="To the moon"](../static/sample.txt)

--- a/components/reference-link.md
+++ b/components/reference-link.md
@@ -28,3 +28,62 @@ The text of the link can be explicitly set by passing as the first part of the c
 Clicking anywhere within the reference link component will navigate to that new page.
 
 From a functionality perspective, there is no difference betwen a `!ref` component and a regular hyperlink. The difference between the two is just how they are presented, with a Reference link component being more prominent than a regular hyperlink.
+
+---
+
+## Custom icon
+
+The `icon` used for the reference link component can be customized using a name/value pair syntax for the `text` and `icon` attributes. This allows for setting a custom `icon` and `text` value at the same time. The `icon` attribute can be initialize with one of the following:
+- [Octicon](https://octicons-primer.vercel.app/octicons/) name
+- emoji `:shortcode:` (please see [Mojee](https://mojee.io/emojis) for a full list of supported Emoji shortcodes)
+- image file URL
+
+The following samples demonstrate setting a custom `icon`:
+
+```
+[!ref icon="rocket"](../guides/getting-started.md)
+[!ref icon=":rocket:"](../guides/getting-started.md)
+[!ref icon="../static/retype-icon.svg"](../guides/getting-started.md)
+```
+
+[!ref icon="rocket"](../guides/getting-started.md)
+[!ref icon=":rocket:"](../guides/getting-started.md)
+[!ref icon="../static/retype-icon.svg"](../guides/getting-started.md)
+
+By default, the referred page title is used as the component text value but the text can be customized by explicityly passing a separate `text` value.
+
+```
+[!ref icon="rocket" text="To the moon"](../guides/getting-started.md)
+```
+
+[!ref icon="rocket" text="To the moon"](../guides/getting-started.md)
+
+---
+
+## Target
+
+Sets the `target` attribute of the reference link and specifies which window or tab to open the link into.
+
+[!ref target="blank" text="Retype"](https://retype.com/)
+
+```md
+[!ref target="blank" text="Retype"](https://retype.com/)
+```
+
+If no `target` is configured, the link will open in the current tab.
+
+The `target` can be set to any value, although `blank` is common and will open the link in a new tab. Retype will automatically transform the value `blank` into `_blank` which is the actual value required by the browser to indicate that a hyperlink should be opened in a new tab.
+
+There are several other values that may be prefixed with an `_` character, including `self`, `parent`, and `top`. The following table demonstrates some common scenarios and naming convention used by Retype to normalize the `target` values.
+
+Config `target` value | Runtime `target` value
+--- | ---
+`blank` | `_blank`
+`parent` | `_parent`
+`top` | `_top`
+`self` | `_self`
+`news1` | `news1`
+`nEWs2` | `news2`
+`recent NEWS` | `recent-news`
+
+See also the [`links.target`](../configuration/project.md#target) configuration.

--- a/components/reference-link.md
+++ b/components/reference-link.md
@@ -35,8 +35,8 @@ From a functionality perspective, there is no difference betwen a `!ref` compone
 
 The `icon` used for the reference link component can be customized using a name/value pair syntax for the `text` and `icon` attributes. This allows for setting a custom `icon` and `text` value at the same time. The `icon` attribute can be initialize with one of the following:
 - [Octicon](https://octicons-primer.vercel.app/octicons/) name
-- emoji `:shortcode:` (please see [Mojee](https://mojee.io/emojis) for a full list of supported Emoji shortcodes)
-- image file URL
+- Emoji `:shortcode:` (please see [Mojee](https://mojee.io/emojis) for a full list of supported Emoji shortcodes)
+- Image file URL
 
 The following samples demonstrate setting a custom `icon`:
 
@@ -50,7 +50,7 @@ The following samples demonstrate setting a custom `icon`:
 [!ref icon=":rocket:"](../guides/getting-started.md)
 [!ref icon="../static/retype-icon.svg"](../guides/getting-started.md)
 
-By default, the referred page title is used as the component text value but the text can be customized by explicityly passing a separate `text` value.
+By default, the referred page title is used as the component text value and the text can be customized by explicitly passing a separate `text` value.
 
 ```
 [!ref icon="rocket" text="To the moon"](../guides/getting-started.md)


### PR DESCRIPTION
This PR adds:
- Documentation for new attributes (`icon` and `target`) of the reference link component
- Enhanced description of the `icon` attribute of the file reference component