### PR TITLE
Fixed dead Octicon links

### DIFF
--- a/about.md
+++ b/about.md
@@ -17,20 +17,20 @@ Do you have a general inquiry? Please feel free to contact us at [hello@retype.c
 
 Retype is only made possible because of the hard work of other amazing open-source and commercial projects.
 
-| Library                                                  | License                                                                    | Role                                                                  |
-| -------------------------------------------------------- | -------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| [Markdig](https://github.com/xoofx/markdig)              | [BSD-2-Clause](https://github.com/xoofx/markdig/blob/master/license.txt)   | Markdown parsing                                                      |
-| [Scriban](https://github.com/scriban/scriban)            | [BSD-2-Clause](https://github.com/scriban/scriban/blob/master/license.txt) | Templating, partials, variables                                       |
+| Library                                                  | License                                                                    | Role                                                                   |
+| -------------------------------------------------------- | -------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| [Markdig](https://github.com/xoofx/markdig)              | [BSD-2-Clause](https://github.com/xoofx/markdig/blob/master/license.txt)   | Markdown parsing                                                       |
+| [Scriban](https://github.com/scriban/scriban)            | [BSD-2-Clause](https://github.com/scriban/scriban/blob/master/license.txt) | Templating, partials, variables                                        |
 | [Mojee](https://mojee.io)                                | [Mojee](https://docs.mojee.io/license/)                                    | [Emoji](/components/emoji.md) parsing and handling                     |
-| [Octicons](https://octicons-primer.vercel.app/octicons/) | [MIT](https://github.com/primer/octicons/blob/main/LICENSE)                | Default bundled [icons](/components/icon.md)                           |
-| [Vue.js](https://vuejs.org/)                             | [MIT](https://github.com/vuejs/vue/blob/dev/LICENSE)                       | Client UI framework                                                   |
-| [Turbo](https://turbo.hotwired.dev/)                     | [MIT](https://github.com/hotwired/turbo/blob/main/MIT-LICENSE)             | HTML over the wire                                                    |
-| [Lunr](https://lunrjs.com/)                               | [MIT](https://github.com/olivernn/lunr.js/blob/master/LICENSE)             | Search index                                                          |
+| [Octicons](https://primer.github.io/octicons/)           | [MIT](https://github.com/primer/octicons/blob/main/LICENSE)                | Default bundled [icons](/components/icon.md)                           |
+| [Vue.js](https://vuejs.org/)                             | [MIT](https://github.com/vuejs/vue/blob/dev/LICENSE)                       | Client UI framework                                                    |
+| [Turbo](https://turbo.hotwired.dev/)                     | [MIT](https://github.com/hotwired/turbo/blob/main/MIT-LICENSE)             | HTML over the wire                                                     |
+| [Lunr](https://lunrjs.com/)                              | [MIT](https://github.com/olivernn/lunr.js/blob/master/LICENSE)             | Search index                                                           |
 | [Prism](https://prismjs.com/)                            | [MIT](https://github.com/PrismJS/prism/blob/master/LICENSE)                | [Code block](/components/code-block.md#syntax-highlighting) formatting |
 | [Mermaid](https://mermaid-js.github.io/mermaid/)         | [MIT](https://github.com/mermaid-js/mermaid/blob/develop/LICENSE)          | [Mermaid](/components/mermaid.md) diagrams                             |
 | [KaTeX](https://github.com/KaTeX/KaTeX)                  | [MIT](https://github.com/KaTeX/KaTeX/blob/master/LICENSE)                  | [Math formula](/components/math-formulas.md) rendering                 |
-| [Clipboard.js](https://clipboardjs.com)                  | [MIT](https://clipboardjs.com/)                                            | Code block copy to clipboard                                          |
-| [YamlDotNet](https://github.com/aaubry/YamlDotNet)       | [MIT](https://github.com/aaubry/YamlDotNet/blob/master/LICENSE.txt)        | YAML parsing                                                          |
+| [Clipboard.js](https://clipboardjs.com)                  | [MIT](https://clipboardjs.com/)                                            | Code block copy to clipboard                                           |
+| [YamlDotNet](https://github.com/aaubry/YamlDotNet)       | [MIT](https://github.com/aaubry/YamlDotNet/blob/master/LICENSE.txt)        | YAML parsing                                                           |
 
 ## License
 

--- a/components/badge.md
+++ b/components/badge.md
@@ -119,7 +119,7 @@ See also the [`links.target`](/configuration/project.md#target) configuration.
 
 ### Octicons
 
-[Octicons](https://octicons-primer.vercel.app/octicons/) can be used as an icon by settiing the `icon` property with the name of the Octicon.
+[Octicons](https://primer.github.io/octicons/) can be used as an icon by settiing the `icon` property with the name of the Octicon.
 
 ```md
 [!badge variant="info" icon="person" text="User" margin="0 8 0 0"]

--- a/components/button.md
+++ b/components/button.md
@@ -109,7 +109,7 @@ See also the [`links.target`](/configuration/project.md#target) configuration.
 
 ### Octicons
 
-[Octicons](https://octicons-primer.vercel.app/octicons/) can be used as an icon by settiing the `icon` property with the name of the Octicon.
+[Octicons](https://primer.github.io/octicons/) can be used as an icon by settiing the `icon` property with the name of the Octicon.
 
 ```md
 [!button variant="info" icon="person" text="User"]

--- a/components/file-download.md
+++ b/components/file-download.md
@@ -33,7 +33,7 @@ Clicking anywhere within the file download component will trigger the web browse
 ## Custom icon
 
 The `icon` used for the file download component can be customized using a name/value pair syntax for the `text` and `icon` attributes. This allows for setting a custom `icon` and `text` value at the same time. The `icon` attribute can be initialize with one of the following:
-- [Octicon](https://octicons-primer.vercel.app/octicons/) name
+- [Octicon](https://primer.github.io/octicons/) name
 - Emoji `:shortcode:` (please see [Mojee](https://mojee.io/emojis) for a full list of supported Emoji shortcodes)
 - Image file URL
 

--- a/components/reference-link.md
+++ b/components/reference-link.md
@@ -35,7 +35,7 @@ From a functionality perspective, there is no difference betwen a `!ref` compone
 ## Custom icon
 
 The `icon` used for the reference link component can be customized using a name/value pair syntax for the `text` and `icon` attributes. This allows for setting a custom `icon` and `text` value at the same time. The `icon` attribute can be initialize with one of the following:
-- [Octicon](https://octicons-primer.vercel.app/octicons/) name
+- [Octicon](https://primer.github.io/octicons/) name
 - Emoji `:shortcode:` (please see [Mojee](https://mojee.io/emojis) for a full list of supported Emoji shortcodes)
 - Image file URL
 

--- a/configuration/page.md
+++ b/configuration/page.md
@@ -267,7 +267,7 @@ Setting `expanded: true` within the metadata of an `.md` page or the paired `.ym
 
 Custom icon for the navigation node of the current page. Default is `null`.
 
-Options include using an [Octicon](https://octicons-primer.vercel.app/octicons/) name, [Emoji](https://mojee.io/emojis/) shortcode, `<svg>` element, or a path to an image file.
+Options include using an [Octicon](https://primer.github.io/octicons/) name, [Emoji](https://mojee.io/emojis/) shortcode, `<svg>` element, or a path to an image file.
 
 ```yml Octicon
 icon: rocket


### PR DESCRIPTION
Replaced several of the now dead https://octicons-primer.vercel.app/octicons/ with the new https://primer.github.io/octicons/