### PR TITLE
Adds permissions lines to workflow samples

### DIFF
--- a/hosting/git-ftp.md
+++ b/hosting/git-ftp.md
@@ -40,6 +40,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     steps:
       - uses: actions/checkout@v2
 
@@ -137,6 +140,9 @@ jobs:
     name: Publish to FTP host
 
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Since Feb 2nd, 2023 this is required (or changing default workflow perms in repo settings). Reference: https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/