### PR TITLE
fix: use correct dotnet sdk version in dockerfile example

### DIFF
--- a/hosting/docker.md
+++ b/hosting/docker.md
@@ -20,7 +20,7 @@ First step is to create a Dockerfile in your project.
 The following sample `Dockerfile` will build the Retype project and create a `httpd` image based container as the output.
 
 ```dockerfile # Dockerfile
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS builder
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS builder
 WORKDIR /build
 COPY . /build
 RUN dotnet tool install retypeapp --tool-path /bin


### PR DESCRIPTION
Super tiny change - got an error in CI about using the wrong dotnet version.