### PR TITLE
chore: update setup-dotnet GitHub Actions to version 4

### DIFF
--- a/.github/workflows/retype-action.yml
+++ b/.github/workflows/retype-action.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 7.0.x
 

--- a/guides/github-actions.md
+++ b/guides/github-actions.md
@@ -61,7 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 7.0.x
 
@@ -120,7 +120,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 7.0.x
 


### PR DESCRIPTION
I have successfully updated the `setup-dotnet` GitHub Actions to the latest version, version four. Throughout this process, I did not encounter any issues related to building, or deploying to Cloudflare Pages, nor did I observe any functionality concerns.

I have not come across any discussions regarding the update process, aside from the issue documented at https://github.com/retypeapp/retype/issues/711. If you are aware of any additional discussions or resources, please feel free to share them.

In conclusion, I believe these changes are ready to be merged. However, if anyone sees a potential problem, please raise it.